### PR TITLE
net-setup: Add option to set-up a bridge

### DIFF
--- a/zeth-zbr.conf
+++ b/zeth-zbr.conf
@@ -1,0 +1,44 @@
+# Configuration file for setting IP addresses for a bridge and a
+# network interface.
+
+INTERFACE="$1"
+BRIDGE="$2"
+
+IF_HWADDR="00:00:5e:00:53:fe"
+BR_HWADDR="00:00:5e:00:53:ff"
+
+IPV6_ADDR_1="2001:db8::2"
+IPV6_ROUTE_1="2001:db8::/64"
+
+IPV4_ADDR_1="192.0.2.2/24"
+IPV4_ROUTE_1="192.0.2.0/24"
+
+CUR_IPV6_ADDRS=$(ip -o -6 addr list $BRIDGE | awk '{print $4}' | cut -d/ -f1)
+CUR_IPV4_ADDRS=$(ip -o -4 addr list $BRIDGE | awk '{print $4}')
+CUR_BR_HWADDR=$(ip -o -br link show $BRIDGE | awk '{print $3}')
+CUR_BR_STATE=$(ip -o -br link show $BRIDGE | awk '{print $2}')
+
+ip link set dev $INTERFACE up
+
+if [ "UP" != "$CUR_BR_STATE" ]; then
+   ip link set dev $BRIDGE up
+fi
+
+if [ "$BR_HWADDR" != "$CUR_BR_HWADDR" ]; then
+   echo "Setting hw address of bridge $BRIDGE"
+   ip link set dev $BRIDGE address $BR_HWADDR
+fi
+
+ip link set dev $INTERFACE address $IF_HWADDR
+
+if [[ "$CUR_IPV6_ADDRS" != *"$IPV6_ADDR_1"* ]]; then
+   ip -6 address add $IPV6_ADDR_1 dev $BRIDGE nodad
+fi
+
+ip -6 route replace $IPV6_ROUTE_1 dev $BRIDGE > /dev/null 2>&1
+
+if [[ "$CUR_IPV4_ADDRS" != *"$IPV4_ADDR_1"* ]]; then
+   ip address add $IPV4_ADDR_1 dev $BRIDGE
+fi
+
+ip route replace $IPV4_ROUTE_1 dev $BRIDGE > /dev/null 2>&1


### PR DESCRIPTION
**THIS IS JUST FOR INTERNAL REVIEW, DO NOT MERGE THIS**

If a bridge is given on the command line:
- if it is not present, create it
- create interface as before and additionally join bridge
- set ip addresses and routes on the bridge, if not already present

Signed-off-by: Christian Taedcke <christian.taedcke@lemonbeat.com>